### PR TITLE
Improve robustness on errors

### DIFF
--- a/lib/choria/colt.rb
+++ b/lib/choria/colt.rb
@@ -36,14 +36,6 @@ module Choria
         task['name']
       end
 
-      def tasks_metadata(tasks, environment)
-        tasks.map do |task|
-          logger.debug "Fetching metadata for task '#{task}' (environment: '#{environment}')"
-          metadata = orchestrator.tasks_support.task_metadata(task, environment)
-          [task, metadata]
-        end.to_h
-      end
-
       return tasks_metadata(tasks_names, environment) if cache.nil?
 
       cached_tasks = cache.load
@@ -53,6 +45,16 @@ module Choria
       cache.save updated_tasks
 
       updated_tasks
+    end
+
+    private
+
+    def tasks_metadata(tasks, environment)
+      tasks.map do |task|
+        logger.debug "Fetching metadata for task '#{task}' (environment: '#{environment}')"
+        metadata = orchestrator.tasks_support.task_metadata(task, environment)
+        [task, metadata]
+      end.to_h
     end
   end
 end

--- a/lib/choria/orchestrator.rb
+++ b/lib/choria/orchestrator.rb
@@ -58,15 +58,15 @@ module Choria
       loop do
         task_status_results = rpc_client.task_status(task_id: task_id).map(&:results)
         logger.debug "Task ##{task_id} status: #{task_status_results}"
-        break if task_completed? task_status_results
+        break if task_terminated? task_status_results
       end
 
       task_status_results
     end
 
-    def task_completed?(results)
+    def task_terminated?(results)
       results.each do |result|
-        return false unless result[:data][:completed]
+        return false if result[:data][:exitcode] == -1
       end
 
       true

--- a/lib/choria/orchestrator.rb
+++ b/lib/choria/orchestrator.rb
@@ -27,8 +27,10 @@ module Choria
       logger.debug "Running task: '#{task.name}' (targets: #{targets.nil? ? 'all' : targets})"
       targets&.each { |target| rpc_client.identity_filter target }
 
-      logger.debug "Filtering targets with classes: #{targets_with_classes}" unless targets_with_classes.nil?
-      targets_with_classes&.each { |klass| rpc_client.class_filter klass }
+      unless targets_with_classes.nil?
+        logger.debug "Filtering targets with classes: #{targets_with_classes}"
+        targets_with_classes.each { |klass| rpc_client.class_filter klass }
+      end
 
       logger.wait 'Discovering targets…'
       raise DiscoverError, 'No request sent, no node discovered' if rpc_client.discover.size.zero?

--- a/lib/choria/orchestrator/task.rb
+++ b/lib/choria/orchestrator/task.rb
@@ -47,9 +47,9 @@ module Choria
 
       def default_input
         parameters_with_defaults = metadata['metadata']['parameters'].reject { |_k, v| v['default'].nil? }
-        parameters_with_defaults.map do |parameter, meta|
-          [parameter, meta['default']]
-        end.to_h
+        parameters_with_defaults.transform_values do |meta|
+          meta['default']
+        end
       end
 
       def validate_inputs


### PR DESCRIPTION
Using `colt` against a error-prone infrastructure spots some errors, this PR make `colt` catching them instead of failing.

Warning, this PR contains:
 - PR #6 