### PR TITLE
Implement continous result display

### DIFF
--- a/lib/choria/colt.rb
+++ b/lib/choria/colt.rb
@@ -19,9 +19,11 @@ module Choria
       @orchestrator = Choria::Orchestrator.new logger: @logger
     end
 
-    def run_bolt_task(task_name, input: {}, targets: nil, targets_with_classes: nil)
+    def run_bolt_task(task_name, input: {}, targets: nil, targets_with_classes: nil, &block)
       logger.debug "Instantiate task '#{task_name}' and validate input"
       task = Choria::Orchestrator::Task.new(task_name, input: input, orchestrator: orchestrator)
+
+      task.on_result(&block) if block_given?
 
       orchestrator.run(task, targets: targets, targets_with_classes: targets_with_classes)
       task.wait

--- a/lib/choria/colt.rb
+++ b/lib/choria/colt.rb
@@ -36,14 +36,6 @@ module Choria
         task['name']
       end
 
-      def tasks_metadata(tasks, environment)
-        tasks.map do |task|
-          logger.debug "Fetching metadata for task '#{task}' (environment: '#{environment}')"
-          metadata = orchestrator.tasks_support.task_metadata(task, environment)
-          [task, metadata]
-        end.to_h
-      end
-
       return tasks_metadata(tasks_names, environment) if cache.nil?
 
       cached_tasks = cache.load
@@ -53,6 +45,16 @@ module Choria
       cache.save updated_tasks
 
       updated_tasks
+    end
+
+    private
+
+    def tasks_metadata(tasks, environment)
+      tasks.map do |task|
+        logger.debug "Fetching metadata for task '#{task}' (environment: '#{environment}')"
+        metadata = orchestrator.tasks_support.task_metadata(task, environment)
+        [task, metadata]
+      end.to_h
     end
   end
 end

--- a/lib/choria/colt/cli.rb
+++ b/lib/choria/colt/cli.rb
@@ -36,11 +36,11 @@ module Choria
 
           targets_with_classes = options['targets_with_classes']&.split(',')
 
-          results = colt.run_bolt_task task_name, input: input, targets: targets, targets_with_classes: targets_with_classes
+          results = colt.run_bolt_task task_name, input: input, targets: targets, targets_with_classes: targets_with_classes do |result|
+            show_result(result)
+          end
 
           File.write 'last_run.json', JSON.pretty_generate(results)
-
-          show_results(results)
         rescue Choria::Orchestrator::Error => e
           raise Thor::Error, "#{e.class}: #{e}"
         end
@@ -124,10 +124,6 @@ module Choria
               Parameters:
               #{JSON.pretty_generate(metadata['metadata']['parameters']).gsub(/^/, '  ')}
             OUTPUT
-          end
-
-          def show_results(results)
-            results.each { |result| show_result(result) }
           end
 
           def show_result(result)

--- a/lib/choria/colt/data_structurer.rb
+++ b/lib/choria/colt/data_structurer.rb
@@ -1,27 +1,25 @@
 module Choria
   class Colt
     module DataStructurer
-      def self.structure(results)
-        results.map do |res|
-          # data.stdout seems to always be JSON, so parse it once.
-          res[:result] = JSON.parse res[:data][:stdout]
-          res[:data].delete :stdout
+      def self.structure(res)
+        # data.stdout seems to always be JSON, so parse it once.
+        res[:result] = JSON.parse res[:data][:stdout]
+        res[:data].delete :stdout
 
-          # On one side, data.stderr is filled by the remote execution stderr.
-          # On the other side, error description is in JSON (ie. '_error')
-          # So merge data.stderr in '_error'.'details'
-          unless res[:data][:stderr].empty?
-            raise NotImplementedError, 'What to do when res[:data][:stderr] contains something?' if res[:result]['_error'].empty?
+        # On one side, data.stderr is filled by the remote execution stderr.
+        # On the other side, error description is in JSON (ie. '_error')
+        # So merge data.stderr in '_error'.'details'
+        unless res[:data][:stderr].empty?
+          raise NotImplementedError, 'What to do when res[:data][:stderr] contains something?' if res[:result]['_error'].empty?
 
-            res[:result]['_error']['details'].merge!({ 'stderr' => res[:data][:stderr].split("\n") })
-          end
-          res[:data].delete :stderr
-
-          # Convert '_output' (ie. stdout) lines into array
-          res[:result]['_output'] = res[:result]['_output'].split("\n")
-
-          res
+          res[:result]['_error']['details'].merge!({ 'stderr' => res[:data][:stderr].split("\n") })
         end
+        res[:data].delete :stderr
+
+        # Convert '_output' (ie. stdout) lines into array
+        res[:result]['_output'] = res[:result]['_output'].split("\n")
+
+        res
       end
     end
   end

--- a/lib/choria/orchestrator.rb
+++ b/lib/choria/orchestrator.rb
@@ -58,15 +58,15 @@ module Choria
       loop do
         task_status_results = rpc_client.task_status(task_id: task_id).map(&:results)
         logger.debug "Task ##{task_id} status: #{task_status_results}"
-        break if task_completed? task_status_results
+        break if task_terminated? task_status_results
       end
 
       task_status_results
     end
 
-    def task_completed?(results)
+    def task_terminated?(results)
       results.each do |result|
-        return false unless result[:data][:completed]
+        return false if result[:data][:exitcode] == -1
       end
 
       true

--- a/lib/choria/orchestrator.rb
+++ b/lib/choria/orchestrator.rb
@@ -27,8 +27,10 @@ module Choria
       logger.debug "Running task: '#{task.name}' (targets: #{targets.nil? ? 'all' : targets})"
       targets&.each { |target| rpc_client.identity_filter target }
 
-      logger.debug "Filtering targets with classes: #{targets_with_classes}" unless targets_with_classes.nil?
-      targets_with_classes&.each { |klass| rpc_client.class_filter klass }
+      unless targets_with_classes.nil?
+        logger.debug "Filtering targets with classes: #{targets_with_classes}"
+        targets_with_classes.each { |klass| rpc_client.class_filter klass }
+      end
 
       logger.wait 'Discovering targets…'
       raise DiscoverError, 'No request sent, no node discovered' if rpc_client.discover.size.zero?

--- a/lib/choria/orchestrator.rb
+++ b/lib/choria/orchestrator.rb
@@ -50,37 +50,15 @@ module Choria
       task.rpc_responses = responses
     end
 
-    def wait_results(task_id:)
-      raise 'Task ID is required!' if task_id.nil?
-
-      logger.wait 'Waiting task results…'
-      task_status_results = nil
-      loop do
-        task_status_results = rpc_client.task_status(task_id: task_id).map(&:results)
-        logger.debug "Task ##{task_id} status: #{task_status_results}"
-        break if task_terminated? task_status_results
-      end
-
-      task_status_results
-    end
-
-    def task_terminated?(results)
-      results.each do |result|
-        return false if result[:data][:exitcode] == -1
-      end
-
-      true
-    end
-
     def validate_rpc_result(result)
       raise Error, "The RPC agent returned an error: #{result[:statusmsg]}" unless (result[:statuscode]).zero?
     end
 
-    private
-
     def rpc_client
       @rpc_client ||= rpcclient('bolt_tasks', options: rpc_options)
     end
+
+    private
 
     def rpc_options
       {

--- a/lib/choria/orchestrator/task.rb
+++ b/lib/choria/orchestrator/task.rb
@@ -47,9 +47,9 @@ module Choria
 
       def default_input
         parameters_with_defaults = metadata['metadata']['parameters'].reject { |_k, v| v['default'].nil? }
-        parameters_with_defaults.map do |parameter, meta|
-          [parameter, meta['default']]
-        end.to_h
+        parameters_with_defaults.transform_values do |meta|
+          meta['default']
+        end
       end
 
       def validate_inputs


### PR DESCRIPTION
This allow to process result as soon as it is received.
    
Through CLI, long running tasks can now display results earlier.

Warning, this PR contains:
 - PR #6 
 - PR #7 